### PR TITLE
Fix regex for projects with numbers

### DIFF
--- a/cfqol.user.js
+++ b/cfqol.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Curseforge QOL Fixes
-// @version      0.20
+// @version      0.21
 // @description  Various Quality of Life improvements to the Curseforge website
 // @author       comp500
 // @namespace    https://infra.link/
@@ -73,7 +73,7 @@
 		.forEach((n) => n.parentNode.removeChild(n));
 
 	// Add an "All Files" tab for all curseforge projects
-	let projectPathMatches = /^\/([\w-]+)\/([\w-]+)\/([a-z][\\da-z-_]{0,127})/.exec(document.location.pathname);
+	let projectPathMatches = /^\/([\w-]+)\/([\w-]+)\/([a-z][\da-z-_]{0,127})/.exec(document.location.pathname);
 	let filesTab = document.getElementById("nav-files");
 	if (projectPathMatches != null && projectPathMatches.length == 4 && filesTab != null) {
 		let gameName = projectPathMatches[1];


### PR DESCRIPTION
Tiny fix to the regex matching for numbers. I had to add two extra backslashes `\\` for the `\d` when I used the `RegExp()` constructor but only one was removed when you converted it back to the literal notation. 